### PR TITLE
Fix return address detection for x86 builds

### DIFF
--- a/src/kernel32_proxy.c
+++ b/src/kernel32_proxy.c
@@ -18,7 +18,7 @@ DWORD WINAPI hook_GetTickCount(void) {
     CONTEXT ctx = {0};
     ctx.ContextFlags = CONTEXT_CONTROL;
     RtlCaptureContext(&ctx);
-#ifdef _M_IX86
+#if defined(_M_IX86) || defined(__i386__)
     DWORD retAddr = ctx.Eip;
 #else
     DWORD retAddr = 0;

--- a/src/ws2_32_proxy.c
+++ b/src/ws2_32_proxy.c
@@ -88,7 +88,7 @@ int WINAPI hook_recv(SOCKET s, char *buf, int len, int flags) {
     CONTEXT ctx = {0}; 
     ctx.ContextFlags = CONTEXT_CONTROL;
     RtlCaptureContext(&ctx);
-#ifdef _M_IX86
+#if defined(_M_IX86) || defined(__i386__)
     uintptr_t ret = ctx.Eip;
 #else
     uintptr_t ret = ctx.Rip;
@@ -120,7 +120,7 @@ int WINAPI hook_send(SOCKET s, const char *buf, int len, int flags) {
     CONTEXT ctx = {0}; 
     ctx.ContextFlags = CONTEXT_CONTROL;
     RtlCaptureContext(&ctx);
-#ifdef _M_IX86
+#if defined(_M_IX86) || defined(__i386__)
     uintptr_t ret = ctx.Eip;
 #else
     uintptr_t ret = ctx.Rip;


### PR DESCRIPTION
handle `__i386__` when compiling hook DLLs with non-MSVC compilers