### PR TITLE
Add MSVC guards for pragma comments

### DIFF
--- a/src/kernel32_proxy.c
+++ b/src/kernel32_proxy.c
@@ -3,7 +3,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include "MinHook.h"
+#ifdef _MSC_VER
 #pragma comment(lib, "MinHook.x86.lib")
+#endif
 
 // Funktionszeiger für das Original
 typedef DWORD (WINAPI *GetTickCount_t)(void);

--- a/src/server_proxy.c
+++ b/src/server_proxy.c
@@ -6,8 +6,10 @@
 #include <shlwapi.h>
 #include "MinHook.h"   // MinHook-Header
 
+#ifdef _MSC_VER
 #pragma comment(lib, "MinHook.x86.lib")  // oder MinHook.x64.lib
 #pragma comment(lib, "Shlwapi.lib")
+#endif
 
 // -----------------------------------------------------------------------------
 // Logging

--- a/src/ws2_32_proxy.c
+++ b/src/ws2_32_proxy.c
@@ -11,11 +11,13 @@
 #include <stdio.h>
 #include "MinHook.h"
 
+#ifdef _MSC_VER
 #pragma comment(lib, "MinHook.x86.lib")
 #pragma comment(lib, "Ws2_32.lib")
 #pragma comment(lib, "Psapi.lib")
 #pragma comment(lib, "Shlwapi.lib")
 #pragma comment(lib, "legacy_stdio_definitions.lib")  // für _snprintf_s
+#endif
 
 // -----------------------------------------------------------------------------
 // Logging mit Zeilenzähler und Roll-Over


### PR DESCRIPTION
guard `#pragma comment` directives behind `#ifdef _MSC_VER`
